### PR TITLE
Add new JsonAuthStrategy + test

### DIFF
--- a/Tests/Strategy/Auth/AuthStrategyTest.php
+++ b/Tests/Strategy/Auth/AuthStrategyTest.php
@@ -4,6 +4,7 @@ namespace Eljam\GuzzleJwt\Tests\Strategy\Auth;
 
 use Eljam\GuzzleJwt\Strategy\Auth\FormAuthStrategy;
 use Eljam\GuzzleJwt\Strategy\Auth\HttpBasicAuthStrategy;
+use Eljam\GuzzleJwt\Strategy\Auth\JsonAuthStrategy;
 use Eljam\GuzzleJwt\Strategy\Auth\QueryAuthStrategy;
 
 /**
@@ -66,5 +67,26 @@ class AuthStrategyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('admin', $authStrategy->getRequestOptions()['auth'][0]);
         $this->assertEquals('password', $authStrategy->getRequestOptions()['auth'][1]);
+    }
+
+    /**
+     * testJsonAuthStrategy.
+     */
+    public function testJsonAuthStrategy()
+    {
+        $authStrategy = new JsonAuthStrategy(
+            [
+                'username' => 'admin',
+                'password' => 'admin',
+                'form_fields' => ['login', 'password'],
+            ]
+        );
+
+        $this->assertTrue(array_key_exists('login', $authStrategy->getRequestOptions()['json']));
+
+        $this->assertTrue(array_key_exists('password', $authStrategy->getRequestOptions()['json']));
+
+        $this->assertEquals('admin', $authStrategy->getRequestOptions()['json']['login']);
+        $this->assertEquals('admin', $authStrategy->getRequestOptions()['json']['password']);
     }
 }

--- a/src/Strategy/Auth/JsonAuthStrategy.php
+++ b/src/Strategy/Auth/JsonAuthStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Eljam\GuzzleJwt\Strategy\Auth;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Guillaume Cavana <guillaume.cavana@gmail.com>
+ */
+class JsonAuthStrategy extends AbstractBaseAuthStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'form_fields' => ['_username', '_password'],
+        ]);
+
+        $resolver->setRequired(['form_fields']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequestOptions()
+    {
+        return [
+            \GuzzleHttp\RequestOptions::JSON => [
+                $this->options['form_fields'][0] => $this->options['username'],
+                $this->options['form_fields'][1] => $this->options['password'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Great bundle, thank you !

We work with an API that give us the JWT, but only accept a POST JSON
encoded body to provide credentials.

I simply reused your FormAuthStrategy modifying the request option key
to GuzzleHttp\RequestOptions::JSON instead of FORM_PARAMS.

Guzzle send the data array json encoded instead of form-data encoding.

I provided the test this new auth strategy, hoping it will fit.