### PR TITLE
Add support for the JWT exp payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ $jwtManager = new JwtManager(
 );
 ```
 
+## Authorization Header Type
+
+Some endpoints use different Authorization header types (Bearer, JWT, etc...).
+
+The default is Bearer, but another type can be supplied in the middleware:
+
+```php
+$stack->push(new JwtMiddleware($jwtManager, 'JWT'));
+```
+
 ## Cached token
 
 To avoid too many calls between multiple request, there is a cache system.

--- a/README.md
+++ b/README.md
@@ -171,3 +171,5 @@ $jwtManager = new JwtManager(
         'expire_key' => 'expires_in', # default is expires_in if not set
     ]
 );
+
+The bundle natively supports the [exp field](https://tools.ietf.org/html/rfc7519.html#section-4.1.4) in the JWT payload.

--- a/Tests/JwtMiddlewareTest.php
+++ b/Tests/JwtMiddlewareTest.php
@@ -39,7 +39,7 @@ class JwtMiddlewareTest extends \PHPUnit_Framework_TestCase
             function (RequestInterface $request) {
                 $this->assertTrue($request->hasHeader('Authorization'));
                 $this->assertSame(
-                    sprintf(JwtMiddleware::AUTH_BEARER, 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'),
+                    'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
                     $request->getHeader('Authorization')[0]
                 );
 
@@ -49,6 +49,44 @@ class JwtMiddlewareTest extends \PHPUnit_Framework_TestCase
 
         $handler = HandlerStack::create($mockHandler);
         $handler->push(new JwtMiddleware($jwtManager));
+
+        $client = new Client(['handler' => $handler]);
+        $client->get('http://api.example.com/api/ping');
+    }
+
+    /**
+     * testJwtAuthorizationHeaderType.
+     */
+    public function testJwtAuthorizationHeaderType()
+    {
+        $authMockHandler = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode(['token' => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'])
+            ),
+        ]);
+
+        $authClient = new Client(['handler' => $authMockHandler]);
+        $jwtManager = new JwtManager(
+            $authClient,
+            (new HttpBasicAuthStrategy(['username' => 'test', 'password' => 'test']))
+        );
+
+        $mockHandler = new MockHandler([
+            function (RequestInterface $request) {
+                $this->assertTrue($request->hasHeader('Authorization'));
+                $this->assertSame(
+                    'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+                    $request->getHeader('Authorization')[0]
+                );
+
+                return new Response(200, [], json_encode(['data' => 'pong']));
+            },
+        ]);
+
+        $handler = HandlerStack::create($mockHandler);
+        $handler->push(new JwtMiddleware($jwtManager, 'JWT'));
 
         $client = new Client(['handler' => $handler]);
         $client->get('http://api.example.com/api/ping');

--- a/src/JwtMiddleware.php
+++ b/src/JwtMiddleware.php
@@ -10,8 +10,6 @@ use Psr\Http\Message\RequestInterface;
  */
 class JwtMiddleware
 {
-    const AUTH_BEARER = 'Bearer %s';
-
     /**
      * $JwtManager.
      *
@@ -20,13 +18,22 @@ class JwtMiddleware
     protected $jwtManager;
 
     /**
+     * The Authorization Header Type (defaults to Bearer)
+     *
+     * @var string
+     */
+    protected $authorizationHeaderType;
+
+    /**
      * Constructor.
      *
      * @param JwtManager $jwtManager
+     * @param string $authorizationHeaderType
      */
-    public function __construct(JwtManager $jwtManager)
+    public function __construct(JwtManager $jwtManager, $authorizationHeaderType = 'Bearer')
     {
         $this->jwtManager = $jwtManager;
+        $this->authorizationHeaderType = $authorizationHeaderType;
     }
 
     /**
@@ -48,9 +55,10 @@ class JwtMiddleware
             $manager
         ) {
             $token = $manager->getJwtToken()->getToken();
+
             return $handler($request->withHeader(
                 'Authorization',
-                sprintf(self::AUTH_BEARER, $token)
+                sprintf('%s %s', $this->authorizationHeaderType, $token)
             ), $options);
         };
     }

--- a/src/Manager/JwtManager.php
+++ b/src/Manager/JwtManager.php
@@ -94,6 +94,13 @@ class JwtManager
 
         if ($expiresIn) {
             $expiration = new \DateTime('now + ' . $expiresIn . ' seconds');
+        } elseif (count($jwtParts = explode('.', $body[$this->options['token_key']])) === 3
+            && is_array($payload = json_decode(base64_decode($jwtParts[1]), true))
+            // https://tools.ietf.org/html/rfc7519.html#section-4.1.4
+            && array_key_exists('exp', $payload)
+        ) {
+            // Manually process the payload part to avoid having to drag in a new library
+            $expiration = new \DateTime('@' . $payload['exp']);
         } else {
             $expiration = null;
         }


### PR DESCRIPTION
The JWT payload sometimes has a "exp" payload (https://tools.ietf.org/html/rfc7519.html#section-4.1.4).

This pull request (based on #8) add support for this.