### PR TITLE
Fix/psr 16 token persistence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - vendor
 
 php:
-  - 5.5
   - 5.6
   - 7.0
 

--- a/Tests/Persistence/TokenPersistenceTest.php
+++ b/Tests/Persistence/TokenPersistenceTest.php
@@ -5,7 +5,8 @@ namespace Eljam\GuzzleJwt\Tests\Persistence;
 use Eljam\GuzzleJwt\JwtToken;
 use Eljam\GuzzleJwt\Persistence\NullTokenPersistence;
 use Eljam\GuzzleJwt\Persistence\SimpleCacheTokenPersistence;
-use Symfony\Component\Cache\Simple\FilesystemCache;
+use Kodus\Cache\MockCache;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * @author Nicolas Reynis (nreynis)
@@ -27,11 +28,27 @@ class TokenPersistenceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * testSimpleCacheTokenPersistenceInterface.
+     * Makes sure we only use the interface methods.
+     */
+    public function testSimpleCacheTokenPersistenceInterface()
+    {
+        $simpleCache = $this->getMock(CacheInterface::class);
+        $tokenPersistence = new SimpleCacheTokenPersistence($simpleCache);
+        $token = new JwtToken('foo', new \DateTime('now'));
+
+        $this->assertNull($tokenPersistence->saveToken($token));
+        $this->assertNull($tokenPersistence->hasToken());
+        $this->assertNull($tokenPersistence->restoreToken());
+        $this->assertNull($tokenPersistence->deleteToken());
+    }
+
+    /**
      * testSimpleCacheTokenPersistence.
      */
     public function testSimpleCacheTokenPersistence()
     {
-        $simpleCache = new FilesystemCache();
+        $simpleCache = new MockCache();
         $tokenPersistence = new SimpleCacheTokenPersistence($simpleCache);
         $token = new JwtToken('foo', new \DateTime('now'));
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "4.5",
         "satooshi/php-coveralls": "^0.6.1",
-        "symfony/cache": ">=3.3"
+        "kodus/mock-cache": "^1.0"
     },
     "require": {
         "php" : ">=5.5.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "kodus/mock-cache": "^1.0"
     },
     "require": {
-        "php" : ">=5.5.0",
+        "php" : ">=5.6.0",
         "guzzlehttp/guzzle": "~6.0",
         "psr/simple-cache": "^1.0",
         "symfony/options-resolver": ">=2.8"

--- a/src/Persistence/SimpleCacheTokenPersistence.php
+++ b/src/Persistence/SimpleCacheTokenPersistence.php
@@ -61,7 +61,7 @@ class SimpleCacheTokenPersistence implements TokenPersistenceInterface
      */
     public function deleteToken()
     {
-        $this->cache->deleteItem($this->cacheKey);
+        $this->cache->delete($this->cacheKey);
         return;
     }
 


### PR DESCRIPTION
Fixes #12. I also had to bump PHP minimal version to 5.6 to accomodate kodus/mock-cache.

PHP 5.5 [support ended 3 years ago](https://www.php.net/supported-versions.php) so this should not be an issue.