### PR TITLE
Update simple-cache requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php" : ">=7.4.0",
         "guzzlehttp/guzzle": "^7.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1 || ^2 || ^3",
         "symfony/options-resolver": ">=2.8",
         "symfony/property-access":">=2.8"
     },


### PR DESCRIPTION
Support simple-cache type additions in 2.0 and 3.0. Since this library
doesn't implement the interface it supports all three versions.

https://www.php-fig.org/psr/psr-16/meta/#82-type-additions

Fixes #20