### PR TITLE
New versions of guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php" : ">=7.4.0",
-        "guzzlehttp/guzzle": "^7.4",
+        "guzzlehttp/guzzle": "^7.0 || ^7.4 || ^7.5",
         "psr/simple-cache": "^1 || ^2 || ^3",
         "symfony/options-resolver": ">=2.8",
         "symfony/property-access":">=2.8"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php" : ">=7.4.0",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^7.4",
         "psr/simple-cache": "^1 || ^2 || ^3",
         "symfony/options-resolver": ">=2.8",
         "symfony/property-access":">=2.8"


### PR DESCRIPTION
Support newer versions of guzzle for compatibility with PHP 8.1 and 8.2