### PR TITLE
Add small safety margin

### DIFF
--- a/src/JwtToken.php
+++ b/src/JwtToken.php
@@ -50,6 +50,6 @@ class JwtToken
             return false;
         }
 
-        return (new \DateTime('now + 1 minutes')) < $this->expiration;
+        return (new \DateTime('now + 1 seconds')) < $this->expiration;
     }
 }

--- a/src/JwtToken.php
+++ b/src/JwtToken.php
@@ -50,6 +50,6 @@ class JwtToken
             return false;
         }
 
-        return (new \DateTime()) < $this->expiration;
+        return (new \DateTime('now + 1 minutes')) < $this->expiration;
     }
 }


### PR DESCRIPTION
See issue: https://github.com/eljam/guzzle-jwt-middleware/issues/24
Sometimes the isValid will give a valid token, but by the time it will execute, the token is expired.
I created a small safety margin of 1 second to overcome this problem.