### PR TITLE
Fix PHP8.4 deprecation

### DIFF
--- a/src/Manager/JwtManager.php
+++ b/src/Manager/JwtManager.php
@@ -68,7 +68,7 @@ class JwtManager
     public function __construct(
         ClientInterface $client,
         AuthStrategyInterface $auth,
-        TokenPersistenceInterface $tokenPersistence = null,
+        ?TokenPersistenceInterface $tokenPersistence = null,
         array $options = []
     ) {
         $this->client = $client;


### PR DESCRIPTION
Fix deprecation warning in PHP8.4:

```
Deprecated: Eljam\GuzzleJwt\Manager\JwtManager::__construct(): Implicitly marking parameter $tokenPersistence as nullable is deprecated, the explicit nullable type must be used instead
```